### PR TITLE
Update code_checks.yml

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-uv venv myenv
-source myenv/bin/activate
+# uv venv myenv
+# source myenv/bin/activate
 
 uv pip install -e .

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# uv venv myenv
-# source myenv/bin/activate
+uv venv
+source .venv/bin/activate
 
-uv pip install -e .
+uv sync

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -28,14 +28,17 @@ jobs:
       with:
         python-version-file: "pyproject.toml"
         
+    - name: install python packages
+      run: uv pip install . --system
+      
     - name: run ruff code checks
-      run: uvx ruff@0.9.5 check
-
+      run: ruff check
+  
     - name: run pyright type-hinting checks
-      run: uvx pyright@1.1.393
+      run: pyright
 
     - name: Run pytest
-      run: uvx pytest@8.3.4
+      run: pytest
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip install . --system
+      run: uv pip sync --system
       
     - name: run ruff code checks
       run: ruff check

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -30,7 +30,10 @@ jobs:
         
     - name: install python packages
       run: uv pip sync pyproject.toml --system
-      
+
+    - name: list python packages
+      run: uv pip list
+
     - name: run ruff code checks
       run: ruff check
   

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip sync --system
+      run: uv pip sync pyproject.toml --system
       
     - name: run ruff code checks
       run: ruff check

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip sync pyproject.toml --system
+      run: uv pip sync --system
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip sync pyproject.toml --system
+      run: uv sync pyproject.toml --system
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv sync --system
+      run: uv sync
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip sync pyproject.toml --system
+      run: uv sync --system
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv sync
+      run: uv pip install . --system
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv pip sync --system
+      run: uv pip sync pyproject.toml --system
 
     - name: list python packages
       run: uv pip list

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -29,7 +29,7 @@ jobs:
         python-version-file: "pyproject.toml"
         
     - name: install python packages
-      run: uv sync pyproject.toml --system
+      run: uv pip sync pyproject.toml --system
 
     - name: list python packages
       run: uv pip list


### PR DESCRIPTION
@cyrille-feu pyright will complain when we start importing packages e.g. `import scipy`, because we do not install all packages in the ci/cd

Now the ci/cd will install all packages. 