### PR TITLE
Add branch reference to checkout step

### DIFF
--- a/.github/workflows/ build_and_deploy.yml
+++ b/.github/workflows/ build_and_deploy.yml
@@ -75,6 +75,8 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # actions/checkout@v4
+        with:
+          ref: 'development'
 
       # Fetch the merged PR's author username using GitHub API
       - name: 'Get PR Author'


### PR DESCRIPTION
Specify the branch reference for the checkout step. this will override the current behaviour of pinning the event SHA to the workflow and allow rebuild of the latest development branch.